### PR TITLE
Update meta.json of unshield.rs 

### DIFF
--- a/unshield.rs/meta.json
+++ b/unshield.rs/meta.json
@@ -1,4 +1,4 @@
 {
-	"rawExt": "imploded",
-	"processedExt": ""
+	"rawExt": "",
+	"processedExt": "imploded"
 }


### PR DESCRIPTION
For all other testdata directories (implode-decoder, pwexplode, zlib_libblase), the imploded version is the "processedExt" and the exploded (clear) version is the "rawExt". Here, it is not. Should be changed for consistency.